### PR TITLE
adding tifton/ATBD_CROPS_nisar-public-ebd-urls.txt

### DIFF
--- a/tifton/ATBD_CROPS_nisar-public-ebd-urls.txt
+++ b/tifton/ATBD_CROPS_nisar-public-ebd-urls.txt
@@ -1,0 +1,11 @@
+https://s3.us-west-1.wasabisys.com/nisar-public-ebd/ATBD/ecosystems/croparea/sites/tifton/GCOV/simulated/NISAR_L2_PR_GCOV_001_001_A_000_2000_SHNA_A_20220125T053357_20220125T053407_T00777_M_F_J_777.h5
+https://s3.us-west-1.wasabisys.com/nisar-public-ebd/ATBD/ecosystems/croparea/sites/tifton/GCOV/simulated/NISAR_L2_PR_GCOV_001_001_A_000_2000_SHNA_A_20220208T053356_20220208T053406_T00777_M_F_J_777.h5
+https://s3.us-west-1.wasabisys.com/nisar-public-ebd/ATBD/ecosystems/croparea/sites/tifton/GCOV/simulated/NISAR_L2_PR_GCOV_001_001_A_000_2000_SHNA_A_20220222T053356_20220222T053406_T00777_M_F_J_777.h5
+https://s3.us-west-1.wasabisys.com/nisar-public-ebd/ATBD/ecosystems/croparea/sites/tifton/GCOV/simulated/NISAR_L2_PR_GCOV_001_001_A_000_2000_SHNA_A_20220308T053356_20220308T053406_T00777_M_F_J_777.h5
+https://s3.us-west-1.wasabisys.com/nisar-public-ebd/ATBD/ecosystems/croparea/sites/tifton/GCOV/simulated/NISAR_L2_PR_GCOV_001_001_A_000_2000_SHNA_A_20220322T053356_20220322T053406_T00777_M_F_J_777.h5
+https://s3.us-west-1.wasabisys.com/nisar-public-ebd/ATBD/ecosystems/croparea/sites/tifton/GCOV/simulated/NISAR_L2_PR_GCOV_001_001_A_000_2000_SHNA_A_20220405T053355_20220405T053405_T00777_M_F_J_777.h5
+https://s3.us-west-1.wasabisys.com/nisar-public-ebd/ATBD/ecosystems/croparea/sites/tifton/GCOV/simulated/NISAR_L2_PR_GCOV_001_001_A_000_2000_SHNA_A_20220517T053354_20220517T053404_T00777_M_F_J_777.h5
+https://s3.us-west-1.wasabisys.com/nisar-public-ebd/ATBD/ecosystems/croparea/sites/tifton/GCOV/simulated/NISAR_L2_PR_GCOV_001_001_A_000_2000_SHNA_A_20220628T053355_20220628T053405_T00777_M_F_J_777.h5
+https://s3.us-west-1.wasabisys.com/nisar-public-ebd/ATBD/ecosystems/croparea/sites/tifton/GCOV/simulated/NISAR_L2_PR_GCOV_001_001_A_000_2000_SHNA_A_20220712T053355_20220712T053405_T00777_M_F_J_777.h5
+https://s3.us-west-1.wasabisys.com/nisar-public-ebd/ATBD/ecosystems/croparea/sites/tifton/GCOV/simulated/NISAR_L2_PR_GCOV_001_001_A_000_2000_SHNA_A_20220726T053355_20220726T053405_T00777_M_F_J_777.h5
+https://s3.us-west-1.wasabisys.com/nisar-public-ebd/ATBD/ecosystems/croparea/sites/tifton/crops/tifton_CDL_2023.tif


### PR DESCRIPTION
The file contains the access urls to the tifton/GCOV and tifton/crops files that are now in the repo (and should be ideally be deleted from the repo). 

The WASABI bucket `nisar-public-ebd` is  located in the WASABI region us-west-1 and is publicly accessible. We can work on write permissions to the bucket to the NISAR ST. 